### PR TITLE
Fix dynamic spaces

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -82,6 +82,8 @@ if (charts_h2 || scales_h2) {
 			}
 		}
 	}
+
+	// Trigger change events to update the charts and scales so they reflect the specified color space
+	select?.dispatchEvent(new Event("change"));
+	select2?.dispatchEvent(new Event("change"));
 }
-
-

--- a/palettes/palette.njk
+++ b/palettes/palette.njk
@@ -86,7 +86,7 @@ eleventyComputed:
 					<small>{{ hues[hue].type }}</small>
 					<input type="checkbox" aria-label="Plot?" checked onchange="document.body.classList.toggle('hide-{{ hue }}', !this.checked)">
 				</th>
-				<td><color-scale data-hue="{{ hue }}" colors="{{ scale | serializeObject }}" info="L: lch.l, C: lch.c, H: lch.h"></color-scale></td>
+				<td><color-scale data-hue="{{ hue }}" colors="{{ scale | serializeObject }}" info="L: oklch.l, C: oklch.c, H: oklch.h"></color-scale></td>
 			</tr>
 		{% endfor %}
 	</tbody>


### PR DESCRIPTION
Changes:

- `<color-scale>` should show info in the same color space as `<color-chart>`
- On loading, trigger `change` events to update the charts and scales so they reflect the specified color space