### PR TITLE
Add unique IDs to color chart elements

### DIFF
--- a/hues/hue.njk
+++ b/hues/hue.njk
@@ -39,7 +39,7 @@
 	Charts
 </h2>
 {% for id, coord in ColorSpaces.oklch.coords %}
-	<color-chart y="oklch.{{ id }}" {{ "x=oklch.l" if id != "l" else "" }} info="L: oklch.l, C: oklch.c, H: oklch.h">
+	<color-chart id="chart-{{ id }}" y="oklch.{{ id }}" {{ "x=oklch.l" if id != "l" else "" }} info="L: oklch.l, C: oklch.c, H: oklch.h">
 		{% for colors in hue.palettes | plotHue -%}
 			<color-scale colors="{{ colors | serializeObject }}" info="L: oklch.l, C: oklch.c, H: oklch.h"></color-scale>
 		{%- endfor %}

--- a/palettes/palette.njk
+++ b/palettes/palette.njk
@@ -63,7 +63,7 @@ eleventyComputed:
 	Charts
 </h2>
 {% for id, coord in ColorSpaces.oklch.coords %}
-	<color-chart y="oklch.{{ id }}" {{ "x=oklch.l" if id != "l" else "" }} info="L: oklch.l, C: oklch.c, H: oklch.h">
+	<color-chart id="chart-{{ id }}" y="oklch.{{ id }}" {{ "x=oklch.l" if id != "l" else "" }} info="L: oklch.l, C: oklch.c, H: oklch.h">
 		{% for hue, scale in palette.colors -%}
 			<color-scale data-hue="{{ hue }}" colors="{{ scale | serializeObject }}"></color-scale>
 		{%- endfor %}


### PR DESCRIPTION
## Summary
Added unique `id` attributes to `<color-chart>` elements across template files to enable direct element targeting and improve accessibility.

## Changes
- Added `id="chart-{{ id }}"` attribute to `<color-chart>` elements in both `hues/hue.njk` and `palettes/palette.njk`
- IDs are dynamically generated based on the coordinate type (e.g., `chart-l`, `chart-c`, `chart-h` for OKLCH color space coordinates)

## Details
This change allows charts to be uniquely identified in the DOM, which enables:
- Direct linking to specific charts via URL fragments
- Easier JavaScript targeting and manipulation
- Improved accessibility for screen readers and automated tools

https://claude.ai/code/session_01KF4q7n3CV3UKjUWuYEAVgj