### PR TITLE
Add JSON endpoints for hues and palettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 **/index.html
+**/index.json
 client_modules
 importmap.js
 

--- a/hues/hue.json.njk
+++ b/hues/hue.json.njk
@@ -1,0 +1,15 @@
+---js
+{
+	layout: false,
+	pagination: {
+		data: "hues",
+		resolve: "values",
+		size: 1,
+		alias: "hue",
+		before: paginationData => paginationData.filter(hue => hue.palette_count > 1)
+	},
+	permalink: "hues/{{ hue.name }}/index.json",
+	eleventyExcludeFromCollections: true,
+}
+---
+{{ hue | dump(2) | safe }}

--- a/palettes/palette.json.njk
+++ b/palettes/palette.json.njk
@@ -1,0 +1,14 @@
+---js
+{
+	layout: false,
+	pagination: {
+		data: "palettes",
+		resolve: "values",
+		size: 1,
+		alias: "palette",
+	},
+	permalink: "palettes/{{ palette.id }}/index.json",
+	eleventyExcludeFromCollections: true,
+}
+---
+{{ palette | dump(2) | safe }}


### PR DESCRIPTION
## Summary
This PR adds JSON API endpoints for individual hues and palettes, enabling programmatic access to color data.

## Key Changes
- **New hue JSON endpoint** (`hues/palette.json.njk`): Generates individual JSON files for each hue with `palette_count > 1`, accessible at `hues/{hue-name}/index.json`
- **New palette JSON endpoint** (`palettes/palette.json.njk`): Generates individual JSON files for each palette, accessible at `palettes/{palette-id}/index.json`
- **Updated .gitignore**: Added `**/index.json` to exclude generated JSON files from version control

## Implementation Details
- Both endpoints use Eleventy's pagination feature to generate one file per item
- The hue endpoint filters to only include hues with multiple palettes using the `before` pagination hook
- Both endpoints are excluded from Eleventy collections via `eleventyExcludeFromCollections: true`
- JSON output is generated using Nunjucks' `dump` filter for clean formatting

https://claude.ai/code/session_01J1U68XBDZnLVBv558FUYLg